### PR TITLE
chore: configure event photo viewer

### DIFF
--- a/content/communitydays/archive.html
+++ b/content/communitydays/archive.html
@@ -11,7 +11,7 @@
     <li>Session recordings</li>
     <li>Presentation slides</li>
     <li>Speaker bios</li>
-    <li>Event photos</li>
+    <li><a href="https://awsug.nz/#/communitydays/archive/photos/index.html">Event photos</a></li>
     <li>Community highlights</li>
 </ul>
 <br />

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /
+


### PR DESCRIPTION
- enables photo viewer with link https://awsug.nz/#/communitydays/archive/photos/index.html
- hosted in `awsugnz-awscommunityday-photos` bucket configured as origin in cloudfront
