### PR TITLE
chore: update link to awscd photos to open in blank

### DIFF
--- a/content/communitydays/archive.html
+++ b/content/communitydays/archive.html
@@ -8,7 +8,7 @@
             <li>Session recordings</li>
             <li>Presentation slides</li>
             <li>Speaker bios</li>
-            <li><a href="https://awsug.nz/communitydays/archive/photos/index.html">Event photos</a></li>
+            <li><a href="https://awsug.nz/communitydays/archive/photos/index.html" target="_blank" rel="noopener noreferrer">Event photos</a></li>
             <li>Community highlights</li>
         </ul>
     </div>


### PR DESCRIPTION
opens the link in new windows/tab